### PR TITLE
Add Double Opt-In Setting

### DIFF
--- a/omnisend-for-gravity-forms/class-omnisendaddon.php
+++ b/omnisend-for-gravity-forms/class-omnisendaddon.php
@@ -447,7 +447,7 @@ class OmnisendAddOn extends GFAddOn {
 
 	public function settings_double_opt_in_details( $field, $echo = true ) { // phpcs:ignore
 		echo '<div class="gform-settings-field">' . esc_html__( 'After checking this, don’t forget to setup custom automations for your double opt-in workflow in Omnisend.', 'omnisend-for-gravity-forms' ) . '</div>';
-		echo '<a target="_blank" href="https://support.omnisend.com/">' . esc_html__( 'Learn more about Double Opt-In for GravityForms', 'omnisend-for-gravity-forms' ) . '</a>';
+		echo '<a target="_blank" href="https://support.omnisend.com/en/articles/12294261-alternative-double-opt-in">' . esc_html__( 'Learn more about Double Opt-In for GravityForms', 'omnisend-for-gravity-forms' ) . '</a>';
 	}
 
 	public function settings_field_mapping_details() {

--- a/omnisend-for-gravity-forms/class-omnisendaddon.php
+++ b/omnisend-for-gravity-forms/class-omnisendaddon.php
@@ -165,6 +165,26 @@ class OmnisendAddOn extends GFAddOn {
 					),
 				),
 			),
+            array(
+				'title'  => esc_html__( 'Double Opt-In', 'omnisend-for-gravity-forms' ),
+				'fields' => array(
+					array(
+						'label'   => esc_html__( 'Check this to enable double opt-in for new subscribers.', 'omnisend-for-gravity-forms' ),
+						'type'    => 'checkbox',
+						'name'    => 'enable_double_opt_in',
+						'choices' => array(
+							array(
+								'label' => esc_html__( 'Enable double opt-in', 'omnisend-for-gravity-forms' ),
+								'name'  => 'double_opt_in',
+							),
+						),
+					),
+					array(
+						'type' => 'double_opt_in_details',
+						'name' => 'double_opt_in_details',
+					),
+				),
+			),
 			array(
 				'title'  => esc_html__( 'Omnisend Field Mapping', 'omnisend-for-gravity-forms' ),
 
@@ -335,7 +355,10 @@ class OmnisendAddOn extends GFAddOn {
 			$contact->add_tag( 'gravity_forms' );
 			$contact->add_tag( 'gravity_forms ' . $form['title'] );
 
-			if ( $email_consent ) {
+            // set_email_opt-In changes status to "subscribed". If Double Opt-in is enabled we want to keep it on "nonSubscribed"
+            if ( isset( $settings['double_opt_in'] ) && $settings['double_opt_in'] == '1' ) {
+				$contact->set_email_consent( 'gravity-forms' );
+			}else{
 				$contact->set_email_consent( 'gravity-forms' );
 				$contact->set_email_opt_in( 'gravity-forms' );
 			}
@@ -422,6 +445,10 @@ class OmnisendAddOn extends GFAddOn {
 		echo '<a target="_blank" href="https://support.omnisend.com/en/articles/1061818-welcome-email-automation">' . esc_html__( 'Learn more about Welcome automation', 'omnisend-for-gravity-forms' ) . '</a>';
 	}
 
+	public function settings_double_opt_in_details( $field, $echo = true ) { // phpcs:ignore
+		echo '<div class="gform-settings-field">' . esc_html__( 'After checking this, don’t forget to setup custom automations for your double opt-in workflow in Omnisend.', 'omnisend-for-gravity-forms' ) . '</div>';
+		echo '<a target="_blank" href="https://support.omnisend.com/">' . esc_html__( 'Learn more about Double Opt-In for GravityForms', 'omnisend-for-gravity-forms' ) . '</a>';
+	}
 
 	public function settings_field_mapping_details() {
 		echo '<div class="gform-settings-field">' . esc_html__( 'Field mapping lets you align your form fields with Omnisend. It\'s important to match them correctly, so the information collected through Gravity Forms goes into the right place in Omnisend.', 'omnisend-for-gravity-forms' ) . '</div>';

--- a/omnisend-for-gravity-forms/class-omnisendaddon.php
+++ b/omnisend-for-gravity-forms/class-omnisendaddon.php
@@ -355,13 +355,15 @@ class OmnisendAddOn extends GFAddOn {
 			$contact->add_tag( 'gravity_forms' );
 			$contact->add_tag( 'gravity_forms ' . $form['title'] );
 
-            // set_email_opt-In changes status to "subscribed". If Double Opt-in is enabled we want to keep it on "nonSubscribed"
-            if ( isset( $settings['double_opt_in'] ) && $settings['double_opt_in'] == '1' ) {
-				$contact->set_email_consent( 'gravity-forms' );
-			}else{
-				$contact->set_email_consent( 'gravity-forms' );
-				$contact->set_email_opt_in( 'gravity-forms' );
-			}
+            // Respect both the double-opt-in setting *and* the submitter’s consent choice
+            if ( $email_consent ) {
+                if ( isset( $settings['double_opt_in'] ) && $settings['double_opt_in'] == '1' ) {
+                    $contact->set_email_consent( 'gravity-forms' );
+                } else {
+                    $contact->set_email_consent( 'gravity-forms' );
+                    $contact->set_email_opt_in( 'gravity-forms' );
+                }
+            }
 
 			if ( $phone_consent ) {
 				$contact->set_phone_consent( 'gravity-forms' ); // todo looks a bit strange. Maybe one function is enough?


### PR DESCRIPTION
**Current Situation**
Currently Omnisend doesnt support any doubleoptin Option for the GravityForms Addon, REST-API.
Submissons over Gravity Forms always get the status "subscribed" - without getting any Opt-In E-Mail.
As this isnt a legal way with GDPR this has to be adjusted.

**Reason**
Inside the GravityForms Addon we see [here ](https://github.com/omnisend/wp-omnisend-gravity-forms/blob/main/omnisend-for-gravity-forms/class-omnisendaddon.php#L340C15-L340C31) that the `set_email_opt_in` gets called.

`
     if ( $email_consent ) {
     				$contact->set_email_consent( 'gravity-forms' );
     				$contact->set_email_opt_in( 'gravity-forms' );
     			}
`


This [function](https://github.com/omnisend/wp-omnisend/blob/ce7f23f426065f7be36c590d6e1b94965df6db09/omnisend/includes/SDK/V1/class-contact.php#L609) from another omnisend plugin sets the status to subscribed
`$this->email_status        = 'subscribed';`

As there is no matching function we should use the fallback "nonSubscribed" and shouldnt call this function in case Double OptIn is required: https://github.com/omnisend/wp-omnisend/blob/ce7f23f426065f7be36c590d6e1b94965df6db09/omnisend/includes/SDK/V1/class-contact.php#L40

**Suggestion**
- This PR gives Users the Option to activate Double Optin.
- When activated the status of the Contact will be "nonSubscribed".
- Then Automations should be implemented to automatically send out the Double Optin Mail (_has to be done manually in Omnisend Portal as Omnisend has no general API or Function for this_)
- When accepting the DOI the user is properly adjusted to status "subscribed" by the automatisation (_not part of this PR - has to be done in Omnisend_)

Fixes #11

**Screenshots**
- New Backend Setting
<img width="1470" height="633" alt="image" src="https://github.com/user-attachments/assets/e70f51bf-c9b5-4aee-b827-5f9f63fba5ca" />

**TODO**
Omnisend should document the need of the Automations to be setup as per example delivered by Sarunas