### PR TITLE
WordPress 6.9 Compatibility - v1.2.8

### DIFF
--- a/omnisend-for-gravity-forms/class-omnisend-addon-bootstrap.php
+++ b/omnisend-for-gravity-forms/class-omnisend-addon-bootstrap.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Omnisend for Gravity Forms Add-On
  * Description: A gravity forms add-on to sync contacts with Omnisend. In collaboration with Omnisnnd for WooCommerce plugin it enables better customer tracking
- * Version: 1.2.7
+ * Version: 1.2.8
  * Author: Omnisend
  * Author URI: https://www.omnisend.com
  * Developer: Omnisend
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 const OMNISEND_GRAVITY_ADDON_NAME    = 'Omnisend for Gravity Forms Add-On';
-const OMNISEND_GRAVITY_ADDON_VERSION = '1.2.7';
+const OMNISEND_GRAVITY_ADDON_VERSION = '1.2.8';
 
 add_action( 'gform_loaded', array( 'Omnisend_AddOn_Bootstrap', 'load' ), 5 );
 

--- a/omnisend-for-gravity-forms/readme.txt
+++ b/omnisend-for-gravity-forms/readme.txt
@@ -3,9 +3,9 @@ Plugin Name: Omnisend for Gravity Forms Add-On
 Contributors: Omnisend
 Tags: Gravity forms, form, email marketing, web tracking, subscriber collection
 Requires at least: 4.7.0
-Tested up to: 6.7
+Tested up to: 6.9
 Requires PHP: 7.1
-Stable tag: 1.2.7
+Stable tag: 1.2.8
 License: GPLv3 or later
 URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -60,6 +60,9 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 7. Convert more visitors with highly-targeted landing pages
 
 == Changelog ==
+
+= 1.2.8 =
+* Verified compatibility with WordPress 6.9
 
 = 1.2.7 =
 * Add double opt-in settings


### PR DESCRIPTION
## What?
Bumped version to 1.2.8 and verified WordPress 6.9 compatibility.

## Why?
To ensure the plugin works correctly with the latest WordPress version.